### PR TITLE
Replace input with textarea with validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "localpost-server"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "ascii",
  "async-std",

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,9 +40,9 @@
   </main>
   <footer class="d-flex justify-center footer">
     <div class="width-keeper">
-      <form action="" method="post" autocomplete="off"  class="sender">
+      <form action="" method="post" autocomplete="off" id="form" class="sender">
         <div class="d-flex mb-1">
-          <input autocomplete="off" name="text" type="text">
+          <textarea form="form" name="text" rows="1" cols="50" required></textarea>
           <input type="submit" value="Send" class="button">
         </div>
         <div class="d-flex">

--- a/templates/static/style.css
+++ b/templates/static/style.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@200;400;700&display=swap');
 
-body, input, button {
+body, input, textarea, button {
     font-family: "JetBrains Mono", monospace;
     font-size: 18px;
 }
@@ -86,7 +86,7 @@ body {
     display: block;
 }
 
-.sender input[type=text] {
+.sender textarea {
     width: 100%;
     padding: 0.5em;
     margin-right: 0.5em;


### PR DESCRIPTION
Enables multiline messages. If you press "Send" while message is empty, it'll refuse to send and show a warning message instead.